### PR TITLE
Fetch rockets data from given API

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,6 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -1,0 +1,37 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+const apiUrl = 'https://api.spacexdata.com/v3/rockets';
+
+export const fetchRockets = createAsyncThunk('rockets/fetchRockets', async () => {
+  const response = await fetch(apiUrl);
+  const rocketsData = await response.json();
+  const selectedData = rocketsData.map(({
+    id,
+    rocket_name: rocketName,
+    rocket_type: rocketType,
+    flickr_images: flickrImage,
+  }) => ({
+    id,
+    rocketName,
+    rocketType,
+    flickrImage,
+  }));
+  return selectedData;
+});
+
+const initialState = {
+  rockets: [],
+};
+const rocketsSlice = createSlice({
+  name: 'rockets',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchRockets.fulfilled, (state, action) => {
+      state.rockets = action.payload;
+    });
+  },
+
+});
+
+export default rocketsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -3,7 +3,6 @@ import dragonReducer from './dragons/dragonSlice';
 
 import rocketReducer, { fetchRockets } from './rockets/rocketsSlice';
 
-
 const store = configureStore({
   reducer: {
     rockets: rocketReducer,

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,10 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit';
 import dragonReducer from './dragons/dragonSlice';
+import rocketReducer, { fetchRockets } from './rockets/rocketsSlice';
 
 const store = configureStore({
   reducer: {
+    rockets: rocketReducer,
+
     dragons: dragonReducer,
   },
 });
+
+store.dispatch(fetchRockets());
 
 export default store;


### PR DESCRIPTION
- Fetch data from the Rockets endpoint (https://api.spacexdata.com/v3/rockets) when the application starts (as Rockets is the default view).
- After fetching data,  data is dispatched to the Redux store:
- id
- name
- type
- flickr_images

- Data is dispatched only once when the page loads.